### PR TITLE
Fix cookie dependency issue in hardhat

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "ts-node": "^10.9.2",
     "typechain": "^8.3.2",
     "typescript": "^5.8.3"
+  },
+  "resolutions": {
+    "cookie": "0.4.1"
   }
 }


### PR DESCRIPTION
Add a `resolutions` field to `package.json` to force a specific version of `cookie`.

* Add a `resolutions` field to `package.json`.
* Specify the desired version of `cookie` as `0.4.1`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/redx94/AstraLink/pull/5?shareId=22bdf376-f151-4372-89a7-85bb74230b20).

## Summary by Sourcery

Bug Fixes:
- Resolve potential dependency conflicts by pinning the cookie package to version 0.4.1